### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ rails g active_genie:install
 4. Configure your credentials in `config/initializers/active_genie.rb`:
 ```ruby
 ActiveGenie.configure do |config|
-  config.openai.api_key = ENV['OPENAI_API_KEY']
+  config.providers.openai.api_key = ENV['OPENAI_API_KEY']
 end
 ```
 


### PR DESCRIPTION
It seems like the installation instructions needs a `.providers` call first 🙌🏼 